### PR TITLE
Add support for PostgreSQL in dynamic DNS updater

### DIFF
--- a/dynamic_update.php
+++ b/dynamic_update.php
@@ -48,6 +48,8 @@ function safe($value) {
     if ($db_type == 'mysql') {
         $value = $db->quote($value, 'text');
         $value = substr($value, 1, -1); // remove quotes
+    } elseif ($db_type == 'pgsql') {
+        $value = pg_escape_string($value);
     } else {
         return status_exit('baddbtype');
     }


### PR DESCRIPTION
Dynamic DNS updater should work not only with MySQL, but also with PostgreSQL.
